### PR TITLE
fix(eslint): コンポーネント組織構造を強制するESLint設定を追加・修正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ C -->|利用| U
 ### コンポーネント層の設計
 コンポーネントを５つの役割に分類し、それぞれの責務と依存関係を定義します
 #### ディレクトリ構成
-```
+```text
 src/components/
 ├── Base/
 ├── Models/
@@ -120,10 +120,10 @@ export const ProductList = (props) => {
 ```
 ProductCard（Base）は純粋な表示、ProductList（Models）はデータ取得とBaseの組み合わせという責務の違いが分かる
 
-####テストファイルの配置
+#### テストファイルの配置
 コンポーネントの分類と同様に、テストファイルの配置もルールが必要です
 テストやStorybookのファイルは、対象のコンポーネントファイルと同じディレクトリに配置することで、関連するファイルを一箇所にまとめて管理します
-```
+```text
 components/Base/Button/
 ├── Button.tsx
 ├── Button.test.tsx
@@ -326,8 +326,8 @@ TypeScriptで定義したデザイントークンは、動的スタイリング�
 
 ```tsx
 // src/components/Base/Card/Card.tsx
-import { colors } from '@/ui/themes/colors';
-import { spacing } from '@/ui/themes/spacing';
+import { colors } from '@/design-system/themes/colors';
+import { spacing } from '@/design-system/themes/spacing';
 
 export const Card = ({ accentColor, children }: Props) => {
   return (
@@ -367,7 +367,7 @@ export function cn(...inputs: ClassValue[]) {
 
 ```tsx
 // 使用例
-import { cn } from '@/ui/utils/cn';
+import { cn } from '@/design-system/utils/cn';
 
 const buttonClass = cn(
   'px-4 py-2 rounded',
@@ -405,7 +405,7 @@ export function useMediaQuery(query: string): boolean {
 }
 
 // src/components/Base/ResponsiveImage/ResponsiveImage.tsx
-import { useMediaQuery } from '@/ui/hooks/useMediaQuery';
+import { useMediaQuery } from '@/design-system/hooks/useMediaQuery';
 
 export const ResponsiveImage = ({ src, srcMobile }: Props) => {
   const isMobile = useMediaQuery('(max-width: 768px)');

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 この構造を実現するため、以下の２層構造を採用します。
 1. コンポーネント層（src/components/）:役割別に5つのディレクトリに分類
-2. UIインフラ層(src/ui/):コンポーネントが利用する共通基盤
+2. UIインフラ層(src/design-system/):コンポーネントが利用する共通基盤
 
 コンポーネント層とUIインフラ層の関係は以下の通りです
 
@@ -18,11 +18,11 @@ flowchart TD
 
 subgraph C[src/components/]
     P[Pages / Models]
-    L[Layouts / UI]
+    L[Layouts / Base]
     P -->|利用| L
 end
 
-subgraph U[src/ui/]
+subgraph U[src/design-system/]
     T[themes / styled / constans ...]
 end
 
@@ -30,8 +30,8 @@ C -->|利用| U
 
 %% 説明:
 %% Pages / Models ← ビジネスロジック
-%% Layouts / UI ← レイアウト・UIパーツ
-%% src/ui ← 共通基盤・スタイル定義
+%% Layouts / Base ← レイアウト・UIパーツ
+%% src/design-system ← 共通基盤・スタイル定義
 ```
 
 ### コンポーネント層の設計
@@ -39,7 +39,7 @@ C -->|利用| U
 #### ディレクトリ構成
 ```
 src/components/
-├── UI/
+├── Base/
 ├── Models/
 ├── Pages/
 ├── Layouts/
@@ -51,7 +51,7 @@ src/components/
 各ディレクトリの役割は以下のように定義します
 | 名前         | 役割                | 格納するコンポーネント例               |
 | ---------- | ----------------- | -------------------------- |
-| UI         | 純粋なUI要素           | Button, Collapse, Image... |
+| Base       | 純粋なUI要素           | Button, Collapse, Image... |
 | Models     | ドメインロジックがある       | ProductList, BrandList...  |
 | Pages      | ページ専用             | HomePage, SearchPage...    |
 | Layouts    | アプリに関わるレイアウト      | Header, Footer...          |
@@ -76,11 +76,11 @@ src/components/
 * **例：** `ProductList`, `BrandList`
 
 4. UIのみの汎用的なコンポーネントか？
-* **YES →** `src/components/UI/` に配置
+* **YES →** `src/components/Base/` に配置
 * **判断基準：** ビジネスロジックを含まない純粋なUI要素
 * **例：** `Button`, `Collapse`, `Image`
 > **重要：**
-> ドメイン固有の名前を持つコンポーネントでも、データを表示するだけならUIに配置
+> ドメイン固有の名前を持つコンポーネントでも、データを表示するだけならBaseに配置
 > Modelsとの違いは **データ取得やビジネスルールを含むかどうか**。
 
 5. UIを伴わないアプリケーション機能か？
@@ -89,10 +89,10 @@ src/components/
 * **例：** `Analytics`, `GlobalStore`
 
 #### 実装例
-##### UIコンポーネント
+##### Baseコンポーネント
 propsで受け取ったデータを表示するだけのシンプルな実装
 ```tsx
-// UI/ProductCard - UI コンポーネント
+// Base/ProductCard - Base コンポーネント
 export const ProductCard = ({ name, price, image }: Props) => (
   <Card>
     <Image src={image} />
@@ -103,9 +103,9 @@ export const ProductCard = ({ name, price, image }: Props) => (
 ```
 
 ##### Models コンポーネント
-データを取得し、UIコンポーネントを組み合わせて表示する
+データを取得し、Baseコンポーネントを組み合わせて表示する
 ```tsx
-// Models/ProductList - ドメインロジック + UI を利用
+// Models/ProductList - ドメインロジック + Base を利用
 export const ProductList = (props) => {
   const { products } = useProductData(props);
 
@@ -118,13 +118,13 @@ export const ProductList = (props) => {
   );
 };
 ```
-ProductCard（UI）は純粋な表示、ProductList（Models）はデータ取得とUIの組み合わせという責務の違いが分かる
+ProductCard（Base）は純粋な表示、ProductList（Models）はデータ取得とBaseの組み合わせという責務の違いが分かる
 
 ####テストファイルの配置
 コンポーネントの分類と同様に、テストファイルの配置もルールが必要です
 テストやStorybookのファイルは、対象のコンポーネントファイルと同じディレクトリに配置することで、関連するファイルを一箇所にまとめて管理します
 ```
-components/UI/Button/
+components/Base/Button/
 ├── Button.tsx
 ├── Button.test.tsx
 ├── Button.stories.tsx
@@ -136,9 +136,9 @@ components/UI/Button/
 コンポーネント間の依存関係は「自分の横か下にある分類のコンポーネントのみ参照してよい」という原則に従います
 
 依存の基本原則：上位から下位への一方向のみ許可
-- Pages（src/components/Pages）: Models、UI、Functionalを参照可能
-- Models・Layouts: UIとFunctionalを参照可能
-- UI: Functionalのみ参照可能
+- Pages（src/components/Pages）: Models、Base、Functionalを参照可能
+- Models・Layouts: BaseとFunctionalを参照可能
+- Base: Functionalのみ参照可能
 - Functional: 外部依存なし（最下位）
 各ディレクトリは、同じディレクトリ内のコンポーネント同士も参照可能です（Pagesを除く）
 > **注記：**
@@ -151,7 +151,7 @@ components/UI/Button/
 設計したディレクトリ構成のルールが守られるよう、ESLintを導入します
 
 ### UIインフラ層の設計
-UIインフラ層（`src/ui/`）は、コンポーネント層が利用する共通基盤として、デザイントークン、ユーティリティ関数、スタイリングソリューションを提供します。この層を適切に設計することで、一貫性のあるUI実装と効率的な開発が可能になります。
+UIインフラ層（`src/design-system/`）は、コンポーネント層が利用する共通基盤として、デザイントークン、ユーティリティ関数、スタイリングソリューションを提供します。この層を適切に設計することで、一貫性のあるUI実装と効率的な開発が可能になります。
 
 #### スタイリングソリューションの選定
 ##### Tailwind CSSの採用
@@ -173,50 +173,50 @@ UIインフラ層（`src/ui/`）は、コンポーネント層が利用する共
 | CSS Modules | スコープの隔離が容易 | グローバルなデザインシステム構築が困難 | レガシーコードベースとの統合時 |
 
 #### 命名に関する重要な注意
-##### `src/components/UI/` と `src/ui/` の区別
+##### `src/components/Base/` と `src/design-system/` の区別
 本テンプレートでは、以下の2つの似た名前のディレクトリが存在します：
 
-- **`src/components/UI/`**: 純粋なUIコンポーネント（Button, Imageなど）
-- **`src/ui/`**: UIインフラ層（デザイントークン、ユーティリティなど）
+- **`src/components/Base/`**: 純粋なUIコンポーネント（Button, Imageなど）
+- **`src/design-system/`**: UIインフラ層（デザイントークン、ユーティリティなど）
 
 **混同を避けるための判断基準:**
 ```text
 ファイルを配置する際の質問:
 ├─ これはReactコンポーネント（.tsxファイル）か？
-│  └─ YES → src/components/UI/
+│  └─ YES → src/components/Base/
 │
 └─ これはデザイントークン、定数、ユーティリティか？
-   └─ YES → src/ui/
+   └─ YES → src/design-system/
 ```
 
 **具体例:**
 ```tsx
-// ❌ 間違い: UIコンポーネントをsrc/ui/に配置
-// src/ui/Button.tsx
+// ❌ 間違い: UIコンポーネントをsrc/design-system/に配置
+// src/design-system/Button.tsx
 export const Button = ({ children }: Props) => <button>{children}</button>
 
-// ✅ 正解: UIコンポーネントはsrc/components/UI/に配置
-// src/components/UI/Button/Button.tsx
+// ✅ 正解: UIコンポーネントはsrc/components/Base/に配置
+// src/components/Base/Button/Button.tsx
 export const Button = ({ children }: Props) => <button>{children}</button>
 
-// ✅ 正解: デザイントークンはsrc/ui/に配置
-// src/ui/themes/colors.ts
+// ✅ 正解: デザイントークンはsrc/design-system/に配置
+// src/design-system/themes/colors.ts
 export const colors = {
   primary: '#3B82F6',
   secondary: '#10B981',
 } as const;
 ```
 
-**将来的な命名変更の検討:**
-混同リスクをさらに低減するため、以下の命名変更も検討に値します：
-- `src/ui/` → `src/design-system/` または `src/theme/`
-- `src/components/UI/` → `src/components/Primitives/` または `src/components/Base/`
+**命名の決定:**
+混同リスクを低減するため、以下の命名を採用しています：
+- `src/design-system/`: UIインフラ層（デザイントークン、ユーティリティなど）
+- `src/components/Base/`: 純粋なUIコンポーネント（Button、Imageなど）
 
-ただし、この変更には既存のドキュメントとの整合性コストが伴うため、プロジェクト開始前に決定することを推奨します。
+この命名により、役割の区別が明確になり、ファイルの配置場所で迷うことを最小化します。
 
 #### ディレクトリ構成
 ```text
-src/ui/
+src/design-system/
 ├── themes/           # デザイントークン（色、サイズ、タイポグラフィ等）
 │   ├── colors.ts     # カラーパレット定義
 │   ├── spacing.ts    # スペーシングシステム
@@ -236,7 +236,7 @@ src/ui/
 
 **実装例:**
 ```typescript
-// src/ui/themes/colors.ts
+// src/design-system/themes/colors.ts
 export const colors = {
   // Primary colors
   primary: {
@@ -257,7 +257,7 @@ type PrimaryShades = keyof typeof colors.primary; // '50' | '100' | '500' | '900
 ```
 
 ```typescript
-// src/ui/themes/spacing.ts
+// src/design-system/themes/spacing.ts
 export const spacing = {
   xs: '0.25rem',  // 4px
   sm: '0.5rem',   // 8px
@@ -275,8 +275,8 @@ export type Spacing = keyof typeof spacing;
 **推奨アプローチ:**
 ```javascript
 // tailwind.config.js
-import { colors } from './src/ui/themes/colors';
-import { spacing } from './src/ui/themes/spacing';
+import { colors } from './src/design-system/themes/colors';
+import { spacing } from './src/design-system/themes/spacing';
 
 export default {
   theme: {
@@ -306,7 +306,7 @@ export default {
 コンポーネントでは、Tailwind CSSのユーティリティクラスを直接使用します。
 
 ```tsx
-// src/components/UI/Button/Button.tsx
+// src/components/Base/Button/Button.tsx
 export const Button = ({ variant = 'primary', children }: Props) => {
   // クラス名の動的な結合にはcnユーティリティを使用
   const className = cn(
@@ -325,7 +325,7 @@ export const Button = ({ variant = 'primary', children }: Props) => {
 TypeScriptで定義したデザイントークンは、動的スタイリングが必要な場合に使用します。
 
 ```tsx
-// src/components/UI/Card/Card.tsx
+// src/components/Base/Card/Card.tsx
 import { colors } from '@/ui/themes/colors';
 import { spacing } from '@/ui/themes/spacing';
 
@@ -353,7 +353,7 @@ export const Card = ({ accentColor, children }: Props) => {
 複数のクラス名を条件付きで結合する場合、`cn`ユーティリティを使用します。
 
 ```typescript
-// src/ui/utils/cn.ts
+// src/design-system/utils/cn.ts
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
@@ -383,12 +383,12 @@ UI レンダリングに直接関わるフック（`useMediaQuery`, `useTheme`�
 
 | フックの種類 | 配置場所 | 判断基準 | 例 |
 |-----------|---------|---------|-----|
-| UIレンダリング直結 | `src/ui/hooks/` | DOMやレスポンシブ、テーマに関連する汎用的なフック | `useMediaQuery`, `useTheme`, `useBreakpoint` |
+| UIレンダリング直結 | `src/design-system/hooks/` | DOMやレスポンシブ、テーマに関連する汎用的なフック | `useMediaQuery`, `useTheme`, `useBreakpoint` |
 | ビジネスロジック | `src/components/Functional/hooks/` | ドメイン固有のデータ取得やビジネスルール | `useProductData`, `useAuth` |
 
 **実装例:**
 ```typescript
-// src/ui/hooks/useMediaQuery.ts
+// src/design-system/hooks/useMediaQuery.ts
 export function useMediaQuery(query: string): boolean {
   const [matches, setMatches] = useState(false);
 
@@ -404,7 +404,7 @@ export function useMediaQuery(query: string): boolean {
   return matches;
 }
 
-// src/components/UI/ResponsiveImage/ResponsiveImage.tsx
+// src/components/Base/ResponsiveImage/ResponsiveImage.tsx
 import { useMediaQuery } from '@/ui/hooks/useMediaQuery';
 
 export const ResponsiveImage = ({ src, srcMobile }: Props) => {
@@ -418,7 +418,7 @@ export const ResponsiveImage = ({ src, srcMobile }: Props) => {
 
 > **Q: このフックはビジネスロジックを含むか？**
 > - **YES** → `src/components/Functional/hooks/`
-> - **NO** → `src/ui/hooks/`
+> - **NO** → `src/design-system/hooks/`
 
 #### 依存関係のルール
 UIインフラ層は、アーキテクチャの最下位層として位置づけられます。
@@ -428,29 +428,29 @@ flowchart TD
     Pages["Pages<br/>(src/components/Pages)"]
     Models["Models<br/>(src/components/Models)"]
     Layouts["Layouts<br/>(src/components/Layouts)"]
-    UI["UI<br/>(src/components/UI)"]
+    Base["Base<br/>(src/components/Base)"]
     Functional["Functional<br/>(src/components/Functional)"]
-    UIInfra["UIインフラ層<br/>(src/ui)"]
+    UIInfra["UIインフラ層<br/>(src/design-system)"]
     External["外部ライブラリ<br/>(Tailwind CSS, React等)"]
 
     Pages --> Models
     Pages --> Layouts
-    Pages --> UI
+    Pages --> Base
     Pages --> Functional
     
-    Models --> UI
+    Models --> Base
     Models --> Functional
     
-    Layouts --> UI
+    Layouts --> Base
     Layouts --> Functional
     
-    UI --> Functional
+    Base --> Functional
     
     %% UIインフラ層への依存
     Pages -.->|利用| UIInfra
     Models -.->|利用| UIInfra
     Layouts -.->|利用| UIInfra
-    UI -.->|利用| UIInfra
+    Base -.->|利用| UIInfra
     Functional -.->|利用| UIInfra
     
     UIInfra --> External
@@ -460,7 +460,7 @@ flowchart TD
 ```
 
 **依存関係のルール:**
-1. **すべてのコンポーネント層** は UIインフラ層（`src/ui/`）を参照可能
+1. **すべてのコンポーネント層** は UIインフラ層（`src/design-system/`）を参照可能
 2. **UIインフラ層** は外部ライブラリ（Tailwind CSS、Reactなど）のみに依存
 3. **UIインフラ層** は `src/components/` 内のどのディレクトリも参照してはならない
 
@@ -468,10 +468,10 @@ flowchart TD
 
 | 層 | 依存可能な層 |
 |----|-----------|
-| Pages | Models, Layouts, UI, Functional, **UIインフラ層** |
-| Models | UI, Functional, **UIインフラ層** |
-| Layouts | UI, Functional, **UIインフラ層** |
-| UI | Functional, **UIインフラ層** |
+| Pages | Models, Layouts, Base, Functional, **UIインフラ層** |
+| Models | Base, Functional, **UIインフラ層** |
+| Layouts | Base, Functional, **UIインフラ層** |
+| Base | Functional, **UIインフラ層** |
 | Functional | **UIインフラ層** |
 | **UIインフラ層** | 外部ライブラリのみ |
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,124 @@
+import js from '@eslint/js';
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tsparser from '@typescript-eslint/parser';
+import importPlugin from 'eslint-plugin-import';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+      import: importPlugin,
+    },
+    settings: {
+      'import/resolver': {
+        typescript: true,
+        node: true,
+      },
+    },
+    rules: {
+      // Component organization rules based on AGENTS.md
+      
+      // Rule 1: Pages cannot import from Layouts
+      'import/no-restricted-paths': [
+        'error',
+        {
+          zones: [
+            // Pages: can import Models, UI, Functional, ui/ (NOT Layouts)
+            {
+              target: './src/components/Pages',
+              from: './src/components/Layouts',
+              message: 'Pages components cannot import from Layouts. Pages can only import from Models, UI, Functional, and src/ui/.',
+            },
+            
+            // Layouts: can import UI, Functional, ui/, and other Layouts (NOT Pages, NOT Models)
+            {
+              target: './src/components/Layouts',
+              from: './src/components/Pages',
+              message: 'Layouts components cannot import from Pages.',
+            },
+            {
+              target: './src/components/Layouts',
+              from: './src/components/Models',
+              message: 'Layouts components cannot import from Models. Layouts can only import from UI, Functional, other Layouts, and src/ui/.',
+            },
+            
+            // Models: can import UI, Functional, ui/, and other Models (NOT Pages, NOT Layouts)
+            {
+              target: './src/components/Models',
+              from: './src/components/Pages',
+              message: 'Models components cannot import from Pages.',
+            },
+            {
+              target: './src/components/Models',
+              from: './src/components/Layouts',
+              message: 'Models components cannot import from Layouts. Models can only import from UI, Functional, other Models, and src/ui/.',
+            },
+            
+            // UI: can import Functional, ui/, and other UI (NOT Pages, NOT Layouts, NOT Models)
+            {
+              target: './src/components/UI',
+              from: './src/components/Pages',
+              message: 'UI components cannot import from Pages.',
+            },
+            {
+              target: './src/components/UI',
+              from: './src/components/Layouts',
+              message: 'UI components cannot import from Layouts. UI can only import from Functional, other UI, and src/ui/.',
+            },
+            {
+              target: './src/components/UI',
+              from: './src/components/Models',
+              message: 'UI components cannot import from Models. UI can only import from Functional, other UI, and src/ui/.',
+            },
+            
+            // Functional: can only import ui/ and other Functional (NOT Pages, NOT Layouts, NOT Models, NOT UI)
+            {
+              target: './src/components/Functional',
+              from: './src/components/Pages',
+              message: 'Functional components cannot import from Pages.',
+            },
+            {
+              target: './src/components/Functional',
+              from: './src/components/Layouts',
+              message: 'Functional components cannot import from Layouts. Functional can only import from other Functional and src/ui/.',
+            },
+            {
+              target: './src/components/Functional',
+              from: './src/components/Models',
+              message: 'Functional components cannot import from Models. Functional can only import from other Functional and src/ui/.',
+            },
+            {
+              target: './src/components/Functional',
+              from: './src/components/UI',
+              message: 'Functional components cannot import from UI. Functional can only import from other Functional and src/ui/.',
+            },
+            
+            // UI Infrastructure Layer (src/ui/): cannot import from any component layer
+            {
+              target: './src/ui',
+              from: './src/components',
+              message: 'UI infrastructure layer (src/ui/) cannot import from any component layer (src/components/). It should only depend on external libraries.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // Special rule for Next.js pages directory (src/pages/)
+    // Next.js routing pages can import from ALL component categories including Layouts
+    files: ['src/pages/**/*.ts', 'src/pages/**/*.tsx'],
+    rules: {
+      'import/no-restricted-paths': 'off',
+    },
+  },
+];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,25 +27,25 @@ export default [
     rules: {
       // Component organization rules based on AGENTS.md
       // Dependency rules (see AGENTS.md lines 139-146):
-      // - Pages: can import Models, UI, Functional, ui/ (NOT Layouts)
-      // - Layouts: can import UI, Functional, other Layouts, ui/ (NOT Pages, NOT Models)
-      // - Models: can import UI, Functional, other Models, ui/ (NOT Pages, NOT Layouts)
-      // - UI: can import Functional, other UI, ui/ (NOT Pages, NOT Layouts, NOT Models)
-      // - Functional: can import other Functional, ui/ only (lowest layer)
-      // - ui/: cannot import from any component layer
+      // - Pages: can import Models, Base, Functional, design-system/ (NOT Layouts)
+      // - Layouts: can import Base, Functional, other Layouts, design-system/ (NOT Pages, NOT Models)
+      // - Models: can import Base, Functional, other Models, design-system/ (NOT Pages, NOT Layouts)
+      // - Base: can import Functional, other Base, design-system/ (NOT Pages, NOT Layouts, NOT Models)
+      // - Functional: can import other Functional, design-system/ only (lowest layer)
+      // - design-system/: cannot import from any component layer
       
       'import/no-restricted-paths': [
         'error',
         {
           zones: [
-            // Pages: can import Models, UI, Functional, ui/ (NOT Layouts)
+            // Pages: can import Models, Base, Functional, design-system/ (NOT Layouts)
             {
               target: './src/components/Pages',
               from: './src/components/Layouts',
-              message: 'Pages components cannot import from Layouts. Pages can only import from Models, UI, Functional, and src/ui/.',
+              message: 'Pages components cannot import from Layouts. Pages can only import from Models, Base, Functional, and src/design-system/.',
             },
             
-            // Layouts: can import UI, Functional, ui/, and other Layouts (NOT Pages, NOT Models)
+            // Layouts: can import Base, Functional, design-system/, and other Layouts (NOT Pages, NOT Models)
             {
               target: './src/components/Layouts',
               from: './src/components/Pages',
@@ -54,10 +54,10 @@ export default [
             {
               target: './src/components/Layouts',
               from: './src/components/Models',
-              message: 'Layouts components cannot import from Models. Layouts can only import from UI, Functional, other Layouts, and src/ui/.',
+              message: 'Layouts components cannot import from Models. Layouts can only import from Base, Functional, other Layouts, and src/design-system/.',
             },
             
-            // Models: can import UI, Functional, ui/, and other Models (NOT Pages, NOT Layouts)
+            // Models: can import Base, Functional, design-system/, and other Models (NOT Pages, NOT Layouts)
             {
               target: './src/components/Models',
               from: './src/components/Pages',
@@ -66,27 +66,27 @@ export default [
             {
               target: './src/components/Models',
               from: './src/components/Layouts',
-              message: 'Models components cannot import from Layouts. Models can only import from UI, Functional, other Models, and src/ui/.',
+              message: 'Models components cannot import from Layouts. Models can only import from Base, Functional, other Models, and src/design-system/.',
             },
             
-            // UI: can import Functional, ui/, and other UI (NOT Pages, NOT Layouts, NOT Models)
+            // Base: can import Functional, design-system/, and other Base (NOT Pages, NOT Layouts, NOT Models)
             {
-              target: './src/components/UI',
+              target: './src/components/Base',
               from: './src/components/Pages',
-              message: 'UI components cannot import from Pages.',
+              message: 'Base components cannot import from Pages.',
             },
             {
-              target: './src/components/UI',
+              target: './src/components/Base',
               from: './src/components/Layouts',
-              message: 'UI components cannot import from Layouts. UI can only import from Functional, other UI, and src/ui/.',
+              message: 'Base components cannot import from Layouts. Base can only import from Functional, other Base, and src/design-system/.',
             },
             {
-              target: './src/components/UI',
+              target: './src/components/Base',
               from: './src/components/Models',
-              message: 'UI components cannot import from Models. UI can only import from Functional, other UI, and src/ui/.',
+              message: 'Base components cannot import from Models. Base can only import from Functional, other Base, and src/design-system/.',
             },
             
-            // Functional: can only import ui/ and other Functional (NOT Pages, NOT Layouts, NOT Models, NOT UI)
+            // Functional: can only import design-system/ and other Functional (NOT Pages, NOT Layouts, NOT Models, NOT Base)
             {
               target: './src/components/Functional',
               from: './src/components/Pages',
@@ -95,24 +95,24 @@ export default [
             {
               target: './src/components/Functional',
               from: './src/components/Layouts',
-              message: 'Functional components cannot import from Layouts. Functional can only import from other Functional and src/ui/.',
+              message: 'Functional components cannot import from Layouts. Functional can only import from other Functional and src/design-system/.',
             },
             {
               target: './src/components/Functional',
               from: './src/components/Models',
-              message: 'Functional components cannot import from Models. Functional can only import from other Functional and src/ui/.',
+              message: 'Functional components cannot import from Models. Functional can only import from other Functional and src/design-system/.',
             },
             {
               target: './src/components/Functional',
-              from: './src/components/UI',
-              message: 'Functional components cannot import from UI. Functional can only import from other Functional and src/ui/.',
+              from: './src/components/Base',
+              message: 'Functional components cannot import from Base. Functional can only import from other Functional and src/design-system/.',
             },
             
-            // UI Infrastructure Layer (src/ui/): cannot import from any component layer
+            // UI Infrastructure Layer (src/design-system/): cannot import from any component layer
             {
-              target: './src/ui',
+              target: './src/design-system',
               from: './src/components',
-              message: 'UI infrastructure layer (src/ui/) cannot import from any component layer (src/components/). It should only depend on external libraries.',
+              message: 'UI infrastructure layer (src/design-system/) cannot import from any component layer (src/components/). It should only depend on external libraries.',
             },
           ],
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,19 +26,18 @@ export default [
     },
     rules: {
       // Component organization rules based on AGENTS.md
+      // Dependency rules (see AGENTS.md lines 436-439, 471):
+      // - Pages: can import Models, Layouts, UI, Functional, ui/
+      // - Layouts: can import UI, Functional, other Layouts, ui/ (NOT Pages, NOT Models)
+      // - Models: can import UI, Functional, other Models, ui/ (NOT Pages, NOT Layouts)
+      // - UI: can import Functional, other UI, ui/ (NOT Pages, NOT Layouts, NOT Models)
+      // - Functional: can import other Functional, ui/ only (lowest layer)
+      // - ui/: cannot import from any component layer
       
-      // Rule 1: Pages cannot import from Layouts
       'import/no-restricted-paths': [
         'error',
         {
           zones: [
-            // Pages: can import Models, UI, Functional, ui/ (NOT Layouts)
-            {
-              target: './src/components/Pages',
-              from: './src/components/Layouts',
-              message: 'Pages components cannot import from Layouts. Pages can only import from Models, UI, Functional, and src/ui/.',
-            },
-            
             // Layouts: can import UI, Functional, ui/, and other Layouts (NOT Pages, NOT Models)
             {
               target: './src/components/Layouts',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,8 +26,8 @@ export default [
     },
     rules: {
       // Component organization rules based on AGENTS.md
-      // Dependency rules (see AGENTS.md lines 436-439, 471):
-      // - Pages: can import Models, Layouts, UI, Functional, ui/
+      // Dependency rules (see AGENTS.md lines 139-146):
+      // - Pages: can import Models, UI, Functional, ui/ (NOT Layouts)
       // - Layouts: can import UI, Functional, other Layouts, ui/ (NOT Pages, NOT Models)
       // - Models: can import UI, Functional, other Models, ui/ (NOT Pages, NOT Layouts)
       // - UI: can import Functional, other UI, ui/ (NOT Pages, NOT Layouts, NOT Models)
@@ -38,6 +38,13 @@ export default [
         'error',
         {
           zones: [
+            // Pages: can import Models, UI, Functional, ui/ (NOT Layouts)
+            {
+              target: './src/components/Pages',
+              from: './src/components/Layouts',
+              message: 'Pages components cannot import from Layouts. Pages can only import from Models, UI, Functional, and src/ui/.',
+            },
+            
             // Layouts: can import UI, Functional, ui/, and other Layouts (NOT Pages, NOT Models)
             {
               target: './src/components/Layouts',

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@commitlint/config-conventional": "^20.0.0",
     "@commitlint/lint": "^20.0.0",
     "@commitlint/prompt-cli": "^20.1.0",
+    "@eslint/js": "^9.39.1",
     "@typescript-eslint/eslint-plugin": "^8.47.0",
     "@typescript-eslint/parser": "^8.47.0",
     "conventional-changelog-conventionalcommits": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "prepare": "husky",
     "commit": "commit",
     "commitlint": "commitlint --edit",
-    "test:commitlint": "vitest run tests/commitlint.spec.ts"
+    "test:commitlint": "vitest run tests/commitlint.spec.ts",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "keywords": [],
   "author": "",
@@ -17,7 +19,12 @@
     "@commitlint/config-conventional": "^20.0.0",
     "@commitlint/lint": "^20.0.0",
     "@commitlint/prompt-cli": "^20.1.0",
+    "@typescript-eslint/eslint-plugin": "^8.47.0",
+    "@typescript-eslint/parser": "^8.47.0",
     "conventional-changelog-conventionalcommits": "^9.1.0",
+    "eslint": "^9.39.1",
+    "eslint-import-resolver-typescript": "^4.4.4",
+    "eslint-plugin-import": "^2.32.0",
     "husky": "^9.1.7",
     "vitest": "^4.0.8"
   }


### PR DESCRIPTION
# fix(eslint): コンポーネント組織構造を強制するESLint設定を追加・修正

## Summary

AGENTS.mdで定義されているコンポーネント組織構造を自動的に強制するESLint設定を実装しました。AGENTS.md内の矛盾について議論の結果、**139-146行の注記に従い、Pages → Layouts のインポートを禁止**する実装としました。

**主な変更:**
- ESLint 9フラット設定形式（eslint.config.mjs）を追加
- `eslint-plugin-import`の`no-restricted-paths`ルールでコンポーネント間の依存関係を強制
- **重要**: Pages → Layouts のインポートを**禁止**（AGENTS.md 139-146行の注記に基づく）
- 欠落していた`@eslint/js`パッケージをdevDependenciesに追加
- 必要なESLintプラグインをインストール: `@typescript-eslint/parser`, `@typescript-eslint/eslint-plugin`, `eslint-plugin-import`, `eslint-import-resolver-typescript`

**現在の依存関係ルール:**
- **Pages**: ✅ Models, UI, Functional, src/ui/ | ❌ **Layouts**
- **Layouts**: ✅ UI, Functional, 他のLayouts, src/ui/ | ❌ Pages, Models
- **Models**: ✅ UI, Functional, 他のModels, src/ui/ | ❌ Pages, Layouts
- **UI**: ✅ Functional, 他のUI, src/ui/ | ❌ Pages, Layouts, Models
- **Functional**: ✅ 他のFunctional, src/ui/ | ❌ Pages, Layouts, Models, UI
- **src/ui/**: ❌ すべてのコンポーネント層（外部ライブラリのみ）
- **src/pages/** (Next.jsルーティング): ✅ すべてのカテゴリ（特別な例外）

## Review & Testing Checklist for Human

⚠️ **重要 - マージ前に以下を確認してください:**

- [ ] **Pages → Layouts 制限の動作確認**: `src/components/Pages/TestPage.tsx` に `import { TestLayout } from '../Layouts/TestLayout/TestLayout';` を追加して、ESLintエラーが発生することを確認してください
- [ ] **AGENTS.mdの矛盾を解消**: AGENTS.md 436-439行（依存関係図）と471行（依存関係表）には「Pages → Layouts 可能」と記載されていますが、このPRは139-146行の注記に従っています。ドキュメントの一貫性を保つため、436-439行と471行を更新するか、別途対応を検討してください
- [ ] **テスト違反ファイルの削除を検討**: `TestPageViolation.tsx`, `TestButtonViolation.tsx`, `TestAnalyticsViolation.tsx`などのテストファイルがコミットされています。これらは検証用に作成したもので、本番コードには不要かもしれません
- [ ] **Next.js対応の確認**: `src/pages/**`用の特別ルールを含んでいますが、現在このディレクトリは存在しません。将来的にNext.jsを使用する予定がない場合、このルールは不要かもしれません

**推奨テスト手順:**
```bash
# 1. 依存関係を再インストール
npm install

# 2. Lintを実行してエラーがないことを確認
npm run lint

# 3. Pages → Layouts の制限をテスト
# src/components/Pages/TestPage.tsx に以下を追加してエラーになることを確認:
# import { TestLayout } from '../Layouts/TestLayout/TestLayout';

# 4. 許可されるインポートをテスト
# src/components/Pages/TestPage.tsx に以下を追加してエラーにならないことを確認:
# import { TestModel } from '../Models/TestModel/TestModel';
```

### Notes

**AGENTS.mdの解釈について:**
このPRは、AGENTS.md 139-146行の注記に従い、「Pages は Models、UI、Functional のみ参照可能」という解釈を採用しています。ただし、AGENTS.md内には以下の矛盾が存在します：
- 139-146行: Pages は Layouts を参照**不可**
- 436-439行（mermaid依存関係図）: `Pages --> Layouts` の矢印が明示
- 471行（依存関係表）: Pages は「Models, Layouts, UI, Functional, UIインフラ層」と記載

メンテナー(@taiga-K)の判断により、139-146行の注記を正として実装しました。ドキュメントの一貫性を保つため、436-439行と471行の更新を推奨します。

**コミット履歴:**
- `2054e4d`: 初期実装（ESLint設定追加）
- `4493cb1`: コードレビュー対応（Pages→Layouts制限削除、@eslint/js追加）
- `2d43df7`: Pages→Layouts制限を再追加（AGENTS.md 139-146行に従う）

**Devinセッションへのリンク**: https://app.devin.ai/sessions/d12cf689f2d343c3b23e348b19df9d1c  
**リクエスト者**: taiga kono (ktaiga322u@gmail.com) / @taiga-K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * ESLintによるリンティングツールとスクリプト（lint / lint:fix）を導入しました。
  * 開発依存にESLint関連パッケージを追加し、コード品質チェックを強化しました.
* **Style / Rules**
  * レイヤー間の参照を制限するインポート規則を追加し、アーキテクチャ境界を厳格化しました。
* **Documentation**
  * ドキュメントで「UI」を「Base」および「design-system」へ名称・参照を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->